### PR TITLE
Update losses_test.py

### DIFF
--- a/research/object_detection/core/losses_test.py
+++ b/research/object_detection/core/losses_test.py
@@ -224,7 +224,7 @@ class SigmoidFocalClassificationLossTest(tf.test.TestCase):
 
   def testEasyExamplesProduceSmallLossComparedToSigmoidXEntropy(self):
     prediction_tensor = tf.constant([[[_logit(0.97)],
-                                      [_logit(0.90)],
+                                      [_logit(0.91)],
                                       [_logit(0.73)],
                                       [_logit(0.27)],
                                       [_logit(0.09)],


### PR DESCRIPTION
testEasyExamplesProduceSmallLossComparedToSigmoidXEntropy failed because of rounding error in https://github.com/tensorflow/models/blob/875fcb3b417cc74852454472d660996401fb13f7/research/object_detection/core/losses_test.py#L249-L250

Furthermore, with this fix, the logit values are symmetric